### PR TITLE
deps: update uuid to 1.8 (fix wasm compatibility)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,6 @@ repository = "https://github.com/PsichiX/typid"
 documentation = "https://docs.rs/typid"
 readme = "README.md"
 
-[features]
-web = ["uuid/wasm-bindgen"]
-
 [dependencies]
-uuid = { version = "0.8", features = ["serde", "v4"] }
+uuid = { version = "1.8", features = ["serde", "v4"] }
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Fixes compilation for wasm target of `bevy_ecs_tilemap`, which uses `navmesh`, which in turn uses `typid`.

Without this PR, the compile currently fails with this error:

```
error[E0599]: no function or associated item named `new_v4` found for struct `Uuid` in the current scope
   --> /home/m/.cargo/registry/src/index.crates.io-6f17d22bba15001f/typid-1.1.1/src/lib.rs:68:23
    |
68  |             id: Uuid::new_v4(),
    |                       ^^^^^^ function or associated item not found in `Uuid`
    |
note: if you're trying to build a new `Uuid` consider using one of the following associated functions:
      uuid::builder::<impl Uuid>::nil
      uuid::builder::<impl Uuid>::from_fields
      uuid::builder::<impl Uuid>::from_fields_le
      uuid::builder::<impl Uuid>::from_u128
      and 4 others
   --> /home/m/.cargo/registry/src/index.crates.io-6f17d22bba15001f/uuid-0.8.2/src/builder/mod.rs:43:5
    |
43  |       pub const fn nil() -> Self {
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^
...
70  | /     pub fn from_fields(
71  | |         d1: u32,
72  | |         d2: u16,
73  | |         d3: u16,
74  | |         d4: &[u8],
75  | |     ) -> Result<Uuid, crate::Error> {
    | |___________________________________^
...
127 | /     pub fn from_fields_le(
128 | |         d1: u32,
129 | |         d2: u16,
130 | |         d3: u16,
131 | |         d4: &[u8],
132 | |     ) -> Result<Uuid, crate::Error> {
    | |___________________________________^
...
162 |       pub const fn from_u128(v: u128) -> Self {
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Using `rustc 1.79.0-nightly (3c85e5624 2024-03-18)`