### PR TITLE
Fix compilation on WASM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typid"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["Patryk 'PsichiX' Budzynski <psichix@gmail.com>"]
 edition = "2018"
 description = "(Typ)ed Unique (Id)entifiers"
@@ -13,3 +13,6 @@ readme = "README.md"
 [dependencies]
 uuid = { version = "1.8", features = ["serde", "v4"] }
 serde = { version = "1", features = ["derive"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+uuid = { version = "1.8", features = ["serde", "v4", "js"] }


### PR DESCRIPTION
The `uuid` crate requires one to to turn on the `js` feature flag whenever on the `wasm32-unknown-unknown` environment.